### PR TITLE
Time interval tuning, exclude magazine+POA combination

### DIFF
--- a/CRM/ElifeToken/Token/ArticlesLast7Days.php
+++ b/CRM/ElifeToken/Token/ArticlesLast7Days.php
@@ -76,13 +76,11 @@ class CRM_ElifeToken_Token_ArticlesLast7Days{
     // Construct the URL
     $path = 'https://prod--gateway.elifesciences.org/search';
 
-    // Start date is midnight this morning - 7 days
-    $startDate = DateTime::createFromFormat('Y-m-d H:i:s', date_format(new DateTime('-7 day'), 'Y-m-d 19:00:00'));
+    // Start date is midnight starting the day of 6 days ago
+    // which means if we execute this at 7PM we cover 6.8 days
+    $startDate = new DateTime('-6 day');
     $query[] = 'start-date='.$startDate->format('Y-m-d');
-
-    // End date is the time of sending
-    $endDate = new DateTime('now');
-    $query[] = 'end-date='.$endDate->format('Y-m-d');
+    // Don't use any end date, get everything that is available
 
     $query[] = 'per-page=100';
 

--- a/CRM/ElifeToken/Token/ArticlesLast7Days.php
+++ b/CRM/ElifeToken/Token/ArticlesLast7Days.php
@@ -137,7 +137,7 @@ class CRM_ElifeToken_Token_ArticlesLast7Days{
   function filterPoa($content){
     $content['items'] = array_filter($content['items'], function($item){
       if(isset($item['status'])){
-        return $item['status'] == 'poa' and !in_array($item['type'], self::$excludeTypes);;
+        return $item['status'] == 'poa' and !in_array($item['type'], array_merge(self::$magazineVorTypes, self::$excludeTypes));
       }
     });
     return $content;

--- a/CRM/ElifeToken/Token/ArticlesLast7Days.php
+++ b/CRM/ElifeToken/Token/ArticlesLast7Days.php
@@ -77,11 +77,11 @@ class CRM_ElifeToken_Token_ArticlesLast7Days{
     $path = 'https://prod--gateway.elifesciences.org/search';
 
     // Start date is midnight this morning - 7 days
-    $startDate = DateTime::createFromFormat('Y-m-d H:i:s', date_format(new DateTime('-7 day'), 'Y-m-d 00:00:00'));
+    $startDate = DateTime::createFromFormat('Y-m-d H:i:s', date_format(new DateTime('-7 day'), 'Y-m-d 19:00:00'));
     $query[] = 'start-date='.$startDate->format('Y-m-d');
 
-    // End date last second of yesterday
-    $endDate = DateTime::createFromFormat('Y-m-d H:i:s', date_format(new DateTime('-1 day'), 'Y-m-d 23:23:59'));
+    // End date is the time of sending
+    $endDate = new DateTime('now');
     $query[] = 'end-date='.$endDate->format('Y-m-d');
 
     $query[] = 'per-page=100';

--- a/CRM/ElifeToken/Token/ArticlesLast7Days.php
+++ b/CRM/ElifeToken/Token/ArticlesLast7Days.php
@@ -154,7 +154,7 @@ class CRM_ElifeToken_Token_ArticlesLast7Days{
 
   function filterMagazine($content){
     $content['items'] = array_filter($content['items'], function($item){
-      return in_array($item['type'], self::$magazineVorTypes);
+      return array_key_exists('status', $item) and $item['status'] == 'vor' and in_array($item['type'], self::$magazineVorTypes);
     });
     return $content;
   }

--- a/test/CRM/ElifeToken/Token/ArticlesLast7DaysTest.php
+++ b/test/CRM/ElifeToken/Token/ArticlesLast7DaysTest.php
@@ -40,7 +40,7 @@ class CRM_ElifeToken_Token_ArticlesLast7DaysTest extends PHPUnit_Framework_TestC
     $this->checkDataStructure($content);
     foreach ($content['items'] as $item) {
       $this->assertArrayHasKey('status', $item);
-      $this->assertSame('vor', $item['status']);
+      $this->assertSame('vor', $item['status'], "Non-VOR included in magazine content: ".var_export($item, true));
       $this->assertContains($item['type'], $this->magazineTypes);
     }
   }

--- a/test/CRM/ElifeToken/Token/ArticlesLast7DaysTest.php
+++ b/test/CRM/ElifeToken/Token/ArticlesLast7DaysTest.php
@@ -17,6 +17,7 @@ class CRM_ElifeToken_Token_ArticlesLast7DaysTest extends PHPUnit_Framework_TestC
     foreach ($content['items'] as $item) {
       $this->assertArrayHasKey('status', $item);
       $this->assertSame('poa', $item['status']);
+      $this->assertNotContains($item['type'], $this->magazineTypes, "No magazine types should appear in the POA token, even if they are POA. In the future they may be modeled with a separate 'magazine poa' token");
     }
   }
 
@@ -28,7 +29,7 @@ class CRM_ElifeToken_Token_ArticlesLast7DaysTest extends PHPUnit_Framework_TestC
     $this->checkDataStructure($content);
     foreach ($content['items'] as $item) {
       $this->assertSame('vor', $item['status']);
-      $this->assertNotContains($item['type'], $this->magazineTypes, "No magazine types should be duplicated in VOR");
+      $this->assertNotContains($item['type'], $this->magazineTypes, "No magazine types should be duplicated in VOR, because they appear in the separate 'magazine' token used in the VOR email");
     }
   }
 
@@ -41,7 +42,7 @@ class CRM_ElifeToken_Token_ArticlesLast7DaysTest extends PHPUnit_Framework_TestC
     foreach ($content['items'] as $item) {
       $this->assertArrayHasKey('status', $item);
       $this->assertSame('vor', $item['status'], "Non-VOR included in magazine content: ".var_export($item, true));
-      $this->assertContains($item['type'], $this->magazineTypes);
+      $this->assertContains($item['type'], $this->magazineTypes, "Magazine content is selected on a few whitelist of types");
     }
   }
 


### PR DESCRIPTION
- from: `00:00:00` of 6 days ago
- to: now (whenever it is sent, usually 7 pm)
- you can never publish after 7 pm or the next eToc will ignore that content
- you can send after 7 pm, or before, the only important thing is not to publish anything new for that day

Moreover, the rare magazine+POA combination:
- must appear only when becomes VOR
- must appear only in magazine section in the VOR email
- must not appear in POA email, as it stands now